### PR TITLE
add proper DOM manipulation for login err messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,12 +215,16 @@ function validateUser(event) {
   const userName = inputUserName.value.match(/^[A-Z][a-z]{7}\d{1,2}$/i);
   const preFix = inputUserName.value.match(/customer/g)
   if (userName === null || preFix === null) {
+    show(userNameErrorMsg);
+    hide(passwordErrorMsg);
     userNameErrorMsg.innerText = "invalid username, please try again"
   } else if (inputPassword.value !== "overlook2021") {
     hide(userNameErrorMsg);
+    show(passwordErrorMsg);
     passwordErrorMsg.innerText = "invalid password, please try again" 
   } else { 
     hide(passwordErrorMsg);
+    hide(userNameErrorMsg); 
     const userId = inputUserName.value.match(/\d+/g)
     findUser(userId)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -234,12 +234,16 @@ function validateManager(event) {
   event.preventDefault();
   const managerUserName = inputUserName.value.match(/manager/g)
   if (managerUserName === null) {
+    show(userNameErrorMsg);
+    hide(passwordErrorMsg);
     userNameErrorMsg.innerText = "invalid username, please try again"
   } else if (inputPassword.value !== "overlook2021") {
     hide(userNameErrorMsg);
+    show(passwordErrorMsg);
     passwordErrorMsg.innerText = "invalid password, please try again" 
   } else {
     hide(passwordErrorMsg)
+    hide(userNameErrorMsg);
     managerLogin();
   }
 }


### PR DESCRIPTION
# Is this a fix or a feature?
- fix
# What is the change?
# What does it fix?
- adds hide and show functions to login validation, it was missing some functionality
# Where should the reviewer start?
# How should this be tested?
- upon logging in all variations of adding an improper user name or password should render the correct message
# Screenshots (if appropriate):
